### PR TITLE
Process the ranges on the network property only on register

### DIFF
--- a/lib/logstash/filters/cidr.rb
+++ b/lib/logstash/filters/cidr.rb
@@ -75,7 +75,7 @@ class LogStash::Filters::CIDR < LogStash::Filters::Base
       @next_refresh = Time.now + @refresh_interval
       lock_for_write { load_file }
     else
-      @network = @network.collect do |n|
+      @network_list = @network.collect do |n|
         begin
           IPAddr.new(n)
         rescue ArgumentError => e
@@ -139,7 +139,7 @@ class LogStash::Filters::CIDR < LogStash::Filters::Base
     end
     address.compact!
 
-    network = @network
+    network = @network_list
 
     if @network_path #in case we are getting networks from an external file
       if needs_refresh?


### PR DESCRIPTION
At the moment when the `network` property is used in the configuration, like:

```
filter {
    cidr {
        address => [ "%{clientip}"]
        network => [ "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
        add_tag => [ "matched" ]
    }
}
```

The different IP/ranges in the `network` array are processed on each event, in practice we end up creating a new `IPAddr` instance for each IP in the `network` +1 from the IP specified in the `address` field for each event. 

This PR moves the initialisation of the different ranges in `network` to the `register` method. Also, this removes the call to the `event.sprintf` when processing the IP networks. Considering that this is coming from the configuration it should use static values. Although, up to this point it was possible to extract the IP networks from the event itself (https://github.com/logstash-plugins/logstash-filter-cidr/blob/master/lib/logstash/filters/cidr.rb#L159).