### PR TITLE
Network array sort

### DIFF
--- a/lib/logstash/filters/cidr.rb
+++ b/lib/logstash/filters/cidr.rb
@@ -163,9 +163,9 @@ class LogStash::Filters::CIDR < LogStash::Filters::Base
         end
       end
     end
+    network.compact! #clean nulls
     # Sort the array by most restrictive cidr first
     network = network.sort_by{  |net| -net.prefix() }
-    network.compact! #clean nulls
     # Try every combination of address and network, first match wins
     address.product(network).each do |a, n|
       @logger.debug("Checking IP inclusion", :address => a, :network => n)

--- a/lib/logstash/filters/cidr.rb
+++ b/lib/logstash/filters/cidr.rb
@@ -163,7 +163,8 @@ class LogStash::Filters::CIDR < LogStash::Filters::Base
         end
       end
     end
-
+    # Sort the array by most restrictive cidr first
+    network = network.sort_by{  |net| -net.prefix() }
     network.compact! #clean nulls
     # Try every combination of address and network, first match wins
     address.product(network).each do |a, n|

--- a/lib/logstash/filters/cidr.rb
+++ b/lib/logstash/filters/cidr.rb
@@ -2,6 +2,7 @@
 require "logstash/filters/base"
 require "logstash/namespace"
 require "ipaddr"
+require "json"
 
 # The CIDR filter is for checking IP addresses in events against a list of
 # network blocks that might contain it. Multiple addresses can be checked
@@ -33,7 +34,49 @@ class LogStash::Filters::CIDR < LogStash::Filters::Base
   #         network => [ "169.254.0.0/16", "fe80::/64" ]
   #       }
   #     }
-  config :network, :validate => :array, :default => []
+  config :network, :validate => :array || :hash , :default => []
+  
+  # The type of data in the external file containing the IP network(s) to check against. Can be "Array" or "Hash". 
+  # If set to "Hash", file must be json formatted. Does nothing unless network_path is set. Example:
+  # [source,ruby]
+  #     filter {
+  #       %PLUGIN% {
+  #         add_tag => [ "linklocal" ]
+  #         address => [ "%{clientip}" ]
+  #         network_type => "Hash"
+  #         network_path => "/etc/logstash/networks.json"
+  #       }
+  #     }
+  config :network_type, :validate => :string, :default => "Array"
+
+  # Return the data corresponding to the network(s) Hash(es). 
+  # If set to true, corresponding hash will be returned to a specified field, or "result" if none are specified. Does nothing unless network_type is Hash. Example:
+  # [source,ruby]
+  #     filter {
+  #       %PLUGIN% {
+  #         add_tag => [ "linklocal" ]
+  #         address => [ "%{clientip}" ]
+  #         network_type => "Hash"
+  #         network_path => "/etc/logstash/networks.json"
+  #         network_return => true
+  #       }
+  #     }
+  config :network_return, :validate => :boolean, :default => false
+
+  # The field with which to return the data corresponding to the network(s) Hash(es). 
+  # If set, corresponding hash will be returned to a specified field, "result" if not specified. Does nothing unless network_type is Hash. Example:
+  # [source,ruby]
+  #     filter {
+  #       %PLUGIN% {
+  #         add_tag => [ "linklocal" ]
+  #         address => [ "%{clientip}" ]
+  #         network_type => "Hash"
+  #         network_path => "/etc/logstash/networks.json"
+  #         network_return => true
+  #         target => "FieldName"
+  #       }
+  #     }
+  config :target, :validate => :string, :default => "result"
 
   # The full path of the external file containing the IP network(s) to check against. Example:
   # [source,ruby]
@@ -100,22 +143,50 @@ class LogStash::Filters::CIDR < LogStash::Filters::Base
   end # def needs_refresh
 
   def load_file
-    begin
-      temporary = File.open(@network_path, "r") {|file| file.read.split(@separator)}
-      if !temporary.empty? #ensuring the file was parsed correctly
-        @network_list = temporary
+    if @network_type.eql?("Hash")
+      begin
+        json_temporary = File.read(@network_path)
+	temporary = JSON.parse(json_temporary)
+        if !temporary.empty? #ensuring the file was parsed correctly
+          @network_list = temporary
+        end
+      rescue
+        if @network_list #if the list was parsed successfully before
+          @logger.error("Error while opening/parsing the file")
+        else
+          raise LogStash::ConfigurationError, I18n.t(
+            "logstash.agent.configuration.invalid_plugin_register",
+            :plugin => "filter",
+            :type => "cidr",
+            :error => "The file containing the network list is invalid, please check the separator character or permissions for the file."
+          )
+        end
       end
-    rescue
-      if @network_list #if the list was parsed successfully before
-        @logger.error("Error while opening/parsing the file")
-      else
-        raise LogStash::ConfigurationError, I18n.t(
-          "logstash.agent.configuration.invalid_plugin_register",
-          :plugin => "filter",
-          :type => "cidr",
-          :error => "The file containing the network list is invalid, please check the separator character or permissions for the file."
-        )
+    elsif @network_type.eql?("Array")
+      begin
+        temporary = File.open(@network_path, "r") {|file| file.read.split(@separator)}
+        if !temporary.empty? #ensuring the file was parsed correctly
+          @network_list = temporary
+        end
+      rescue
+        if @network_list #if the list was parsed successfully before
+          @logger.error("Error while opening/parsing the file")
+        else
+          raise LogStash::ConfigurationError, I18n.t(
+            "logstash.agent.configuration.invalid_plugin_register",
+            :plugin => "filter",
+            :type => "cidr",
+            :error => "The file containing the network list is invalid, please check the separator character or permissions for the file."
+          )
+        end
       end
+    else
+      raise LogStash::ConfigurationError, I18n.t(
+        "logstash.agent.configuration.invalid_plugin_register",
+        :plugin => "filter",
+        :type => "cidr",
+        :error => "When defining network_type, value must be one of Array or Hash."
+      )
     end
   end #def load_file
 
@@ -140,38 +211,71 @@ class LogStash::Filters::CIDR < LogStash::Filters::Base
           end
         end #end lock
       end #end refresh from file
-
-      network = @network_list.collect do |n|
-        begin
-          lock_for_read do
-            IPAddr.new(n)
+      if @network_type.eql?("Hash")
+	network = @network_list.keys.collect do |n|
+          begin
+            lock_for_read do
+              IPAddr.new(n)
+            end
+          rescue ArgumentError => e
+            @logger.warn("Invalid IP network, skipping", :network => n, :event => event.to_hash)
+            nil
           end
-        rescue ArgumentError => e
-          @logger.warn("Invalid IP network, skipping", :network => n, :event => event.to_hash)
-          nil
+        end
+      
+      elsif @network_type.eql?("Array")
+        network = @network_list.collect do |n|
+          begin
+            lock_for_read do
+              IPAddr.new(n)
+            end
+          rescue ArgumentError => e
+            @logger.warn("Invalid IP network, skipping", :network => n, :event => event.to_hash)
+            nil
+          end
         end
       end
-
     else #networks come from array in config file
-
-      network = @network.map {|nw| event.sprintf(nw) }.map {|nw| nw.split(",") }.flatten.collect do |n|
-        begin
-          IPAddr.new(n.strip)
-        rescue ArgumentError => e
-          @logger.warn("Invalid IP network, skipping", :network => n, :event => event.to_hash)
-          nil
+      if @network.is_a?(Hash)
+        network = @network.keys {|nw| event.sprintf(nw) }.map {|nw| nw.split(",") }.flatten.collect do |n|
+          begin
+            IPAddr.new(n.strip)
+          rescue ArgumentError => e
+            @logger.warn("Invalid IP network, skipping", :network => n, :event => event.to_hash)
+            nil
+          end
+        end
+      elsif @network.is_a?(Array)
+        network = @network.map {|nw| event.sprintf(nw) }.map {|nw| nw.split(",") }.flatten.collect do |n|
+          begin
+            IPAddr.new(n.strip)
+          rescue ArgumentError => e
+            @logger.warn("Invalid IP network, skipping", :network => n, :event => event.to_hash)
+            nil
+          end
         end
       end
+      network = network.sort_by{ |net| -net.prefix() }
     end
+
     network.compact! #clean nulls
-    # Sort the array by most restrictive cidr first
-    network = network.sort_by{  |net| -net.prefix() }
     # Try every combination of address and network, first match wins
     address.product(network).each do |a, n|
       @logger.debug("Checking IP inclusion", :address => a, :network => n)
       if n.include?(a)
-        filter_matched(event)
-        return
+	if (@network.is_a?(Hash) || @network_list.is_a?(Hash)) and @network_return
+	  if @network.is_a?(Hash)
+	    val = @network["#{n.to_s}/#{n.prefix()}"]
+	  elsif @network_list.is_a?(Hash)
+	    val = @network_list["#{n.to_s}/#{n.prefix()}"]
+	  end
+	  event.set(@target, val)
+          filter_matched(event)
+          return
+	else
+          filter_matched(event)
+          return
+	end
       end
     end
   end # def filter


### PR DESCRIPTION
#16 
Sorts network array by cidr (descending)
Enhances the current first match wins method by making the first match the most restrictive
With ["10.0.0.0/8","10.1.0.0/16"], currently 10.1.0.1 would match 10.0.0.0/8, even though it's not the best match
This new method allows this example to match to 10.1.0.0/16, regardless of the initial array order
Also adds hash support for network objects, adds the following fields:
network_type => "Array||Hash" (type for the network object, defaults to Array)
network_return => true||false (do you want to return the value of a matching subnet key, defaults to false)
target => "anystring" (the destination field for the returned value, defaults to 'result')
You can then point the network_path to a json formatted file which would be structured something like this:
{
  "10.1.0.0/16": "my internal network",
  "192.168.1.0/24": "my other internal network"
}

Alternatively, you can just call the plugin from within the pipeline like this:
cidr {
  address=> [ "10.1.1.1" ]
  target => "network"
  network_return => true
  network => {
    "10.1.0.0/16" => "my internal network"
  }
}